### PR TITLE
가로스크롤 커스텀 훅 생성

### DIFF
--- a/src/components/common/BottomSheet.tsx
+++ b/src/components/common/BottomSheet.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @emotion/react */
 
-import { useState, useEffect, useContext } from 'react';
+import React, { useState, useEffect, useContext, useRef, MutableRefObject } from 'react';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled'
 import { ReactComponent as BreweryIcon } from 'atoms/icons/BreweryIcon.svg';
@@ -11,6 +11,7 @@ import { brewerlyType } from 'types/drinkType';
 import close from 'atoms/icons/CloseIcon.svg'
 import { useRecoilState } from 'recoil';
 import { bottomSheetOpened } from 'components/atoms/atoms';
+import { useHorizontalScroll } from 'components/hooks/useHorizontalScroll';
 
 const container = css({
     maxWidth: 375,
@@ -110,6 +111,7 @@ export default function BottomSheetContainer() {
     const [isAnimating, setIsAnimating] = useState(false);
     const [data, setData] = useState<brewerlyType | undefined>()
     const [isOpen, setIsOpen] = useRecoilState<boolean>(bottomSheetOpened);
+    const scrollRef = useHorizontalScroll();
     const { y } = useSpring({
         y: isOpen ? 0 : 120,
         config: { tension: 200, friction: 30 },
@@ -124,6 +126,7 @@ export default function BottomSheetContainer() {
     };
 
     const contextData = useContext(MapContext);
+    
     useEffect(() => {
         if (contextData?.data) {
             setData(contextData?.data)
@@ -159,7 +162,7 @@ export default function BottomSheetContainer() {
                         <AddressFont>{data?.address}</AddressFont>
                     </div>
                     <CardViewGradient />
-                    <CardViewContainer>
+                    <CardViewContainer ref={scrollRef}>
                         {data?.alcohols.length ?
                             <BrewerlyDetailCardView alcohols={data.alcohols} /> :
                             <CenterBold>상품 정보가 없습니다.</CenterBold>

--- a/src/components/hooks/useHorizontalScroll.tsx
+++ b/src/components/hooks/useHorizontalScroll.tsx
@@ -1,0 +1,22 @@
+import {useRef, useEffect, MutableRefObject} from 'react';
+
+export function useHorizontalScroll() : MutableRefObject<HTMLDivElement | null> {
+    const scrollRef = useRef<HTMLDivElement>(null);
+    useEffect(() => {
+        const el = scrollRef.current;
+        if(el){
+            const onWheel = (e:WheelEvent) => {
+                if (e.deltaY === 0) return;
+                e.preventDefault();
+                el.scrollTo({
+                    left: el.scrollLeft + e.deltaY,
+                    behavior: "smooth"
+                });
+            };
+            el.addEventListener('wheel', onWheel);
+            return () => el.removeEventListener('wheel', onWheel);
+        }
+    }, [])
+    return scrollRef;
+
+}


### PR DESCRIPTION
바텀시트가 모바일에선 스크롤이 되는데 PC에선 스크롤이 안되서
커스텀 훅 추가하여 적용함.

필요 시 
`const scrollRef = useHorizontalScroll();  // 스크롤 커스텀 훅 불러오기 `
스크롤 돌릴 컨테이너에 ref={scrollref} 먹이면 끝