### PR TITLE
페이지 로드 시 이미지 반짝거림 해결

### DIFF
--- a/src/components/common/ImageComp.tsx
+++ b/src/components/common/ImageComp.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import styled from "@emotion/styled";
-import Spinner from "./Spinner";
+// import Spinner from "./Spinner";
 import { BoxStyleInterface, isLoadedType, ImageInterface } from "types/ImageCompType";
 
 const LoadedView = styled.div((props: isLoadedType) => ({
@@ -13,7 +13,7 @@ const SkeletonBox = styled.div(() => ({
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
-    background: '#eeeeee',
+    background: '#ffffff',
     borderRadius: 'inherit',
     cursor: 'progress',
 
@@ -43,7 +43,7 @@ const ImageComp = ({ src, alt, size }: ImageInterface) => {
             {
                 isLoading &&
                 <SkeletonBox>
-                    <Spinner />
+                    {/* <Spinner /> */}
                 </SkeletonBox>
             }
             <LoadedView isLoaded={!isLoading}>

--- a/src/components/common/ImageComp.tsx
+++ b/src/components/common/ImageComp.tsx
@@ -28,30 +28,23 @@ const Wrapper = styled.div(({ width, height, borderRadius, margin, padding }: Bo
     flexShrink: 0,
 }))
 
-const Image = React.memo(({ src, alt, onload }: ImageInterface) => {
-    return <img src={src} alt={alt} onLoad={onload} />
-})
+// const Image = React.memo(({ src, alt, onload }: ImageInterface) => {
+//     return <img src={src} alt={alt} onLoad={onload} />
+// })
 
-const ImageComp = ({ src, alt, size }: ImageInterface) => {
-    const [isLoading, setIsLoading] = useState(true);
+const Image = ({ src, alt, onload }: ImageInterface) => {
+    return <img src={src} alt={alt}/>
+}
 
-    const handleImageLoad = () => {
-        setIsLoading(false);
-    }
+const ImageComp = React.memo(({ src, alt, size }: ImageInterface) => {
     return (
         <Wrapper width={size.width} height={size.height} borderRadius={size.borderRadius} margin={size.margin}>
-            {
-                isLoading &&
                 <SkeletonBox>
-                    {/* <Spinner /> */}
+                    <Image src={src} alt={alt} size={size}/>
                 </SkeletonBox>
-            }
-            <LoadedView isLoaded={!isLoading}>
-                <Image src={src} alt={alt} size={size} onload={handleImageLoad} />
-            </LoadedView>
         </Wrapper>
     )
-}
+})
 
 
 export default ImageComp;


### PR DESCRIPTION
#56 문제 해결.

imageComp 내 state가 있어서 state에 따라 re-render가 발생해서 깜빡거렸음.
해당 state 부분 제거 후 정상 동작.